### PR TITLE
Refactor provisioners for better modularity

### DIFF
--- a/incant/config_manager.py
+++ b/incant/config_manager.py
@@ -135,7 +135,7 @@ class ConfigManager:
 
     def _validate_provision_step(self, step: Any, step_idx: int, name: str) -> None:
         if isinstance(step, str):
-            REGISTERED_PROVISIONERS.get("script")(self.incus, self.reporter).validate_config(name, step)
+            REGISTERED_PROVISIONERS["script"](self.incus, self.reporter).validate_config(name, step)
             return
 
         if not isinstance(step, dict):
@@ -157,7 +157,7 @@ class ConfigManager:
                 f"Accepted types are {', '.join(REGISTERED_PROVISIONERS.keys())}."
             )
 
-        REGISTERED_PROVISIONERS.get(key)(self.incus, self.reporter).validate_config(name, value)
+        REGISTERED_PROVISIONERS[key](self.incus, self.reporter).validate_config(name, value)
 
     def _validate_provisioning(self, instance: InstanceConfig, name: str):
         if instance.provision is None:

--- a/incant/provisioners/__init__.py
+++ b/incant/provisioners/__init__.py
@@ -1,7 +1,7 @@
 from .base import REGISTERED_PROVISIONERS, Provisioner
 from .copy_file import CopyFile
-from .llmr import LLMR
+from .llmnr import LLMNR
 from .script import Script
 from .ssh_server import SSHServer
 
-__all__ = ["CopyFile", "LLMR", "Provisioner", "REGISTERED_PROVISIONERS", "Script", "SSHServer"]
+__all__ = ["CopyFile", "LLMNR", "Provisioner", "REGISTERED_PROVISIONERS", "Script", "SSHServer"]

--- a/incant/provisioners/__init__.py
+++ b/incant/provisioners/__init__.py
@@ -1,0 +1,7 @@
+from .base import REGISTERED_PROVISIONERS, Provisioner
+from .copy_file import CopyFile
+from .llmr import LLMR
+from .script import Script
+from .ssh_server import SSHServer
+
+__all__ = ["CopyFile", "LLMR", "Provisioner", "REGISTERED_PROVISIONERS", "Script", "SSHServer"]

--- a/incant/provisioners/base.py
+++ b/incant/provisioners/base.py
@@ -14,7 +14,7 @@ class Provisioner(abc.ABC):
 
     # The name of the key used to identify this provisioner in the
     # incant config.
-    config_key: ClassVar[str] = None
+    config_key: ClassVar[str] = ""
 
     def __init__(self, incus_cli: "IncusCLI", reporter: Reporter):
         self.incus = incus_cli

--- a/incant/provisioners/base.py
+++ b/incant/provisioners/base.py
@@ -1,0 +1,35 @@
+import abc
+import typing
+from typing import ClassVar, Union
+
+if typing.TYPE_CHECKING:
+    from incant import IncusCLI
+from incant.reporter import Reporter
+
+REGISTERED_PROVISIONERS: dict[str, type["Provisioner"]] = {}
+
+
+class Provisioner(abc.ABC):
+    """Abstract class, defining the interface for provisioners."""
+
+    # The name of the key used to identify this provisioner in the
+    # incant config.
+    config_key: ClassVar[str] = None
+
+    def __init__(self, incus_cli: "IncusCLI", reporter: Reporter):
+        self.incus = incus_cli
+        self.reporter = reporter
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        REGISTERED_PROVISIONERS[cls.config_key] = cls
+
+    @abc.abstractmethod
+    def validate_config(self, instance_name: str, config: Union[bool, dict, str]):
+        """Validate the given config."""
+        pass
+
+    @abc.abstractmethod
+    def provision(self, instance_name: str, config: Union[bool, dict, str]):
+        """Run the provisioning logic."""
+        pass

--- a/incant/provisioners/copy_file.py
+++ b/incant/provisioners/copy_file.py
@@ -1,0 +1,83 @@
+import re
+from typing import Union
+
+from ..exceptions import ConfigurationError
+from ..types import FilePushConfig
+from .base import Provisioner
+
+
+class CopyFile(Provisioner):
+    config_key = "copy"
+
+    def validate_config(self, instance_name: str, config: Union[bool, dict, str]):
+        if not isinstance(config, dict):
+            raise ConfigurationError(
+                f"Provisioning 'copy' step in instance '{instance_name}' must have a dictionary value."
+            )
+
+        required_fields = ["source", "target"]
+        missing = [field for field in required_fields if field not in config]
+        if missing:
+            raise ConfigurationError(
+                (
+                    f"Provisioning 'copy' step in instance '{instance_name}' is missing required "
+                    f"field(s): {', '.join(missing)}."
+                )
+            )
+        if not isinstance(config["source"], str) or not isinstance(config["target"], str):
+            raise ConfigurationError(
+                (
+                    f"Provisioning 'copy' step in instance '{instance_name}' "
+                    "must have string 'source' and 'target'."
+                )
+            )
+
+        if "uid" in config and not isinstance(config["uid"], int):
+            raise ConfigurationError(
+                (
+                    f"Provisioning 'copy' step in instance '{instance_name}' "
+                    "has invalid 'uid': must be an integer."
+                )
+            )
+        if "gid" in config and not isinstance(config["gid"], int):
+            raise ConfigurationError(
+                (
+                    f"Provisioning 'copy' step in instance '{instance_name}' "
+                    "has invalid 'gid': must be an integer."
+                )
+            )
+        if "mode" in config:
+            mode_val = config["mode"]
+            if not isinstance(mode_val, str):
+                raise ConfigurationError(
+                    (
+                        f"Provisioning 'copy' step in instance '{instance_name}' has invalid 'mode': "
+                        "must be a string like '0644'."
+                    )
+                )
+            if re.fullmatch(r"[0-7]{3,4}", mode_val) is None:
+                raise ConfigurationError(
+                    (
+                        f"Provisioning 'copy' step in instance '{instance_name}' has invalid 'mode': "
+                        "must be 3-4 octal digits (e.g., '644' or '0644')."
+                    )
+                )
+        if "recursive" in config and not isinstance(config["recursive"], bool):
+            raise ConfigurationError(
+                (
+                    f"Provisioning 'copy' step in instance '{instance_name}'"
+                    "has invalid 'recursive': must be a boolean."
+                )
+            )
+        if "create_dirs" in config and not isinstance(config["create_dirs"], bool):
+            raise ConfigurationError(
+                (
+                    f"Provisioning 'copy' step in instance '{instance_name}' "
+                    "has invalid 'create_dirs': must be a boolean."
+                )
+            )
+
+    def provision(self, instance_name: str, config: dict):
+        """Copy a file to the instance."""
+        config["instance_name"] = instance_name
+        self.incus.file_push(FilePushConfig(**config))

--- a/incant/provisioners/copy_file.py
+++ b/incant/provisioners/copy_file.py
@@ -77,7 +77,9 @@ class CopyFile(Provisioner):
                 )
             )
 
-    def provision(self, instance_name: str, config: dict):
+    def provision(self, instance_name: str, config: Union[bool, dict, str]):
         """Copy a file to the instance."""
+        if not isinstance(config, dict):
+            raise TypeError(f"Config for CopyFile provisioner must be a dict, got {type(config)}")
         config["instance_name"] = instance_name
         self.incus.file_push(FilePushConfig(**config))

--- a/incant/provisioners/llmnr.py
+++ b/incant/provisioners/llmnr.py
@@ -4,8 +4,8 @@ from ..exceptions import ConfigurationError, IncusCommandError
 from .base import Provisioner
 
 
-class LLMR(Provisioner):
-    config_key = "llmr"
+class LLMNR(Provisioner):
+    config_key = "llmnr"
 
     def validate_config(self, instance_name: str, config: Union[bool, dict, str]):
         if not isinstance(config, bool):

--- a/incant/provisioners/llmnr.py
+++ b/incant/provisioners/llmnr.py
@@ -68,8 +68,10 @@ EOF
         self.reporter.info("Restarting systemd-resolved...")
         self.incus.exec(instance_name, ["systemctl", "restart", "systemd-resolved"])
 
-    def provision(self, instance_name: str, config: bool) -> None:
+    def provision(self, instance_name: str, config: Union[bool, dict, str]) -> None:
         """Enable LLMNR on an instance."""
+        if not isinstance(config, bool):
+            raise TypeError(f"Config for LLMNR provisioner must be a bool, got {type(config)}")
         if not config:
             return
 

--- a/incant/provisioners/llmr.py
+++ b/incant/provisioners/llmr.py
@@ -1,0 +1,83 @@
+from typing import Union
+
+from ..exceptions import ConfigurationError, IncusCommandError
+from .base import Provisioner
+
+
+class LLMR(Provisioner):
+    config_key = "llmr"
+
+    def validate_config(self, instance_name: str, config: Union[bool, dict, str]):
+        if not isinstance(config, bool):
+            raise ConfigurationError(
+                f"Provisioning 'llmnr' step in instance '{instance_name}' must have a boolean value."
+            )
+
+    def _install_systemd_resolved(self, instance_name: str):
+        """Install systemd-resolved."""
+        self.reporter.info("Installing systemd-resolved...")
+        try:
+            self.incus.exec(instance_name, ["sh", "-c", "command -v apt-get"], capture_output=True)
+            self.incus.exec(
+                instance_name,
+                ["sh", "-c", "apt-get update && apt-get -y install systemd-resolved"],
+                capture_output=False,
+            )
+            return
+        except IncusCommandError:
+            pass  # apt-get not found, try next package manager
+
+        try:
+            self.incus.exec(instance_name, ["sh", "-c", "command -v dnf"], capture_output=True)
+            self.incus.exec(
+                instance_name, ["sh", "-c", "dnf -y -q install systemd-resolved"], capture_output=False
+            )
+            return
+        except IncusCommandError:
+            pass  # dnf not found
+
+        try:
+            self.incus.exec(instance_name, ["sh", "-c", "command -v pacman"], capture_output=True)
+            self.incus.exec(
+                instance_name,
+                ["sh", "-c", "pacman -Syu --noconfirm systemd-resolvconf"],
+                capture_output=False,
+            )
+            return
+        except IncusCommandError:
+            pass  # pacman not found
+
+        self.reporter.warning(
+            "Could not install systemd-resolved. No supported package manager (apt-get, dnf, pacman) found."
+        )
+
+    def _configure_llmnr(self, instance_name: str):
+        """Configure LLMNR in resolved.conf."""
+        self.reporter.info("Configuring LLMNR...")
+        script = """
+mkdir -p /etc/systemd/resolved.conf.d
+cat <<EOF > /etc/systemd/resolved.conf.d/llmnr.conf
+[Resolve]
+LLMNR=yes
+EOF
+"""
+        self.incus.exec(instance_name, ["sh", "-c", script])
+
+    def _restart_systemd_resolved(self, instance_name: str):
+        """Restart systemd-resolved service."""
+        self.reporter.info("Restarting systemd-resolved...")
+        self.incus.exec(instance_name, ["systemctl", "restart", "systemd-resolved"])
+
+    def provision(self, instance_name: str, config: bool) -> None:
+        """Enable LLMNR on an instance."""
+        if not config:
+            return
+
+        self.reporter.success(f"Enabling LLMNR on instance {instance_name}...")
+        try:
+            self._install_systemd_resolved(instance_name)
+            self._configure_llmnr(instance_name)
+            self._restart_systemd_resolved(instance_name)
+            self.reporter.success(f"LLMNR enabled on {instance_name}.")
+        except IncusCommandError as e:
+            self.reporter.error(f"Failed to enable LLMNR on {instance_name}: {e}")

--- a/incant/provisioners/script.py
+++ b/incant/provisioners/script.py
@@ -1,12 +1,16 @@
+from typing import Union
+
 from .base import Provisioner
 
 
 class Script(Provisioner):
     config_key = "script"
 
-    def validate_config(self, instance_name: str, config: str):
+    def validate_config(self, instance_name: str, config: Union[bool, dict, str]):
         pass
 
-    def provision(self, instance_name: str, config: str):
+    def provision(self, instance_name: str, config: Union[bool, dict, str]):
         """Run a shell script."""
+        if not isinstance(config, str):
+            raise TypeError(f"Config for Script provisioner must be a str, got {type(config)}")
         self.incus.run_script(instance_name, config)

--- a/incant/provisioners/script.py
+++ b/incant/provisioners/script.py
@@ -1,0 +1,12 @@
+from .base import Provisioner
+
+
+class Script(Provisioner):
+    config_key = "script"
+
+    def validate_config(self, instance_name: str, config: str):
+        pass
+
+    def provision(self, instance_name: str, config: str):
+        """Run a shell script."""
+        self.incus.run_script(instance_name, config)

--- a/incant/provisioners/ssh_server.py
+++ b/incant/provisioners/ssh_server.py
@@ -1,0 +1,176 @@
+import glob
+import os
+import subprocess  # nosec B404
+import tempfile
+from pathlib import Path
+from typing import TypedDict, Union
+
+from ..exceptions import ConfigurationError, IncusCommandError
+from ..types import FilePushConfig
+from .base import Provisioner
+
+
+class PackageManager(TypedDict):
+    check_cmd: str
+    install_cmds: list[str]
+
+
+class SSHServer(Provisioner):
+    config_key = "ssh"
+
+    def validate_config(self, instance_name: str, config: Union[bool, dict, str]):
+        if not isinstance(config, (bool, dict)):
+            raise ConfigurationError(
+                f"Provisioning 'ssh' step in instance '{instance_name}' "
+                "must have a boolean or dictionary value."
+            )
+
+    def clean_known_hosts(self, name: str) -> None:
+        """Remove an instance's name from the known_hosts file and add the new host key."""
+        self.reporter.success(
+            f"Updating {name} in known_hosts to avoid SSH warnings...",
+        )
+        known_hosts_path = Path.home() / ".ssh" / "known_hosts"
+        if known_hosts_path.exists():
+            try:
+                # Remove existing entry
+                subprocess.run(
+                    ["ssh-keygen", "-R", name], check=False, capture_output=True
+                )  # nosec B603, B607
+            except FileNotFoundError as e:
+                raise IncusCommandError("ssh-keygen not found, cannot clean known_hosts.") from e
+
+        # Initiate a connection to accept the new host key
+        try:
+            subprocess.run(  # nosec B603, B607
+                [
+                    "ssh",
+                    "-o",
+                    "StrictHostKeyChecking=accept-new",
+                    "-o",
+                    "BatchMode=yes",
+                    "-o",
+                    "ConnectTimeout=5",
+                    name,
+                    "exit",  # Just connect and exit
+                ],
+                check=False,  # Don't raise an error if connection fails (e.g., SSH not ready yet)
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            self.reporter.warning(
+                "ssh command not found, cannot add new host key to known_hosts.",
+            )
+
+    def _install_ssh_server(self, name: str) -> bool:
+        """Installs SSH server in the instance."""
+        package_managers: list[PackageManager] = [
+            {
+                "check_cmd": "command -v apt-get",
+                "install_cmds": ["apt-get update && apt-get -y install ssh"],
+            },
+            {
+                "check_cmd": "command -v dnf",
+                "install_cmds": [
+                    "dnf -y -q install openssh-server",
+                    "systemctl enable sshd",
+                    "systemctl start sshd",
+                ],
+            },
+            {
+                "check_cmd": "command -v pacman",
+                "install_cmds": [
+                    "pacman -Syu --noconfirm openssh",
+                    "systemctl enable sshd",
+                    "systemctl start sshd",
+                ],
+            },
+        ]
+
+        for pm in package_managers:
+            try:
+                self.incus.exec(name, ["sh", "-c", pm["check_cmd"]], capture_output=True)
+                for cmd in pm["install_cmds"]:
+                    self.incus.exec(name, ["sh", "-c", cmd], capture_output=False)
+                return True  # Installed
+            except IncusCommandError:
+                continue  # Try next package manager
+        return False  # Not installed
+
+    def _get_authorized_keys_content(self, ssh_config: Union[dict, bool]) -> str:
+        """Determines the content for authorized_keys."""
+        source_path_str = ssh_config.get("authorized_keys") if isinstance(ssh_config, dict) else None
+
+        if source_path_str:
+            source_path = Path(source_path_str).expanduser()
+            if source_path.exists():
+                with open(source_path, "r", encoding="utf-8") as f:
+                    return f.read()
+            else:
+                self.reporter.warning(
+                    f"Provided authorized_keys file not found: {source_path}. Skipping copy.",
+                )
+                return ""
+        else:
+            # Concatenate all public keys from ~/.ssh/id_*.pub
+            ssh_dir = Path.home() / ".ssh"
+            pub_keys_content = []
+            key_files = glob.glob(os.path.join(ssh_dir, "id_*.pub"))
+
+            for key_file_path in key_files:
+                with open(key_file_path, "r", encoding="utf-8") as f:
+                    pub_keys_content.append(f.read().strip())
+
+            if pub_keys_content:
+                return "\n".join(pub_keys_content) + "\n"
+            else:
+                self.reporter.warning(
+                    "No public keys found in ~/.ssh/id_*.pub and no authorized_keys file provided. "
+                    "SSH access might not be possible without a password.",
+                )
+                return ""
+
+    def _write_authorized_keys(self, name: str, content: str) -> None:
+        """Writes the authorized_keys content to the instance."""
+        if not content:
+            return
+
+        self.reporter.success(f"Filling authorized_keys in {name}...")
+        self.incus.exec(name, ["mkdir", "-p", "/root/.ssh"])
+
+        fd, temp_path = tempfile.mkstemp(prefix="incant_authorized_keys_")
+        try:
+            with os.fdopen(fd, "w") as temp_file:
+                temp_file.write(content)
+
+            self.incus.file_push(
+                FilePushConfig(
+                    instance_name=name,
+                    source=temp_path,
+                    target="/root/.ssh/authorized_keys",
+                    uid=0,
+                    gid=0,
+                    quiet=True,
+                )
+            )
+        finally:
+            os.remove(temp_path)
+
+    def provision(self, instance_name: str, config: Union[dict, bool]) -> None:
+        """Install SSH server and copy authorized_keys."""
+        if isinstance(config, bool):
+            config = {"clean_known_hosts": True}
+
+        self.reporter.success(f"Installing SSH server in {instance_name}...")
+        if not self._install_ssh_server(instance_name):
+            self.reporter.error(
+                f"Failed to install SSH server in {instance_name}. "
+                "No supported package manager (apt-get, dnf, pacman) found.",
+            )
+            return
+
+        content = self._get_authorized_keys_content(config)
+        self._write_authorized_keys(instance_name, content)
+
+        if config.get("clean_known_hosts"):
+            self.clean_known_hosts(instance_name)

--- a/incant/provisioners/ssh_server.py
+++ b/incant/provisioners/ssh_server.py
@@ -156,8 +156,10 @@ class SSHServer(Provisioner):
         finally:
             os.remove(temp_path)
 
-    def provision(self, instance_name: str, config: Union[dict, bool]) -> None:
+    def provision(self, instance_name: str, config: Union[bool, dict, str]) -> None:
         """Install SSH server and copy authorized_keys."""
+        if not isinstance(config, (bool, dict)):
+            raise TypeError(f"Config for SSHServer provisioner must be a bool or dict, got {type(config)}")
         if isinstance(config, bool):
             config = {"clean_known_hosts": True}
 

--- a/incant/provisioning_manager.py
+++ b/incant/provisioning_manager.py
@@ -29,11 +29,11 @@ class ProvisionManager:
                 self.reporter.info(f"Running provisioning step {step_idx} ...")
                 if isinstance(step, dict):
                     step_provisioner_type, step_config = tuple(step.items())[0]
-                    REGISTERED_PROVISIONERS.get(step_provisioner_type)(self.incus, self.reporter).provision(
+                    REGISTERED_PROVISIONERS[step_provisioner_type](self.incus, self.reporter).provision(
                         instance_name, step_config
                     )
                 else:
-                    REGISTERED_PROVISIONERS.get("script")(self.incus, self.reporter).provision(
+                    REGISTERED_PROVISIONERS["script"](self.incus, self.reporter).provision(
                         instance_name, step
                     )
         else:

--- a/incant/provisioning_manager.py
+++ b/incant/provisioning_manager.py
@@ -2,22 +2,10 @@
 Provisioning management for Incant.
 """
 
-import glob
-import os
-import subprocess  # nosec B404
-import tempfile
-from pathlib import Path
-from typing import TypedDict, Union
-
-from .exceptions import IncusCommandError
 from .incus_cli import IncusCLI
+from .provisioners import REGISTERED_PROVISIONERS
 from .reporter import Reporter
-from .types import FilePushConfig, ProvisionSteps
-
-
-class PackageManager(TypedDict):
-    check_cmd: str
-    install_cmds: list[str]
+from .types import ProvisionSteps
 
 
 class ProvisionManager:
@@ -32,239 +20,21 @@ class ProvisionManager:
         if provisions:
             self.reporter.success(f"Provisioning instance {instance_name}...")
 
-            # Handle provisioning steps
+            # Handle special "script" single-step provisioning.
             if isinstance(provisions, str):
-                self.incus.run_script(instance_name, provisions)
-            elif isinstance(provisions, list):
-                for step in provisions:
-                    if isinstance(step, dict) and "copy" in step:
-                        step["copy"]["instance_name"] = instance_name
-                        self.incus.file_push(FilePushConfig(**step["copy"]))
-                    elif isinstance(step, dict) and "ssh" in step:
-                        self.ssh_setup(instance_name, step["ssh"])
-                    elif isinstance(step, dict) and "llmnr" in step:
-                        self.llmnr_setup(instance_name, step["llmnr"])
-                    else:
-                        self.reporter.info("Running provisioning step ...")
-                        self.incus.run_script(instance_name, step)
+                provisions = [provisions]
+
+            # Handle provisioning steps
+            for step_idx, step in enumerate(provisions):
+                self.reporter.info(f"Running provisioning step {step_idx} ...")
+                if isinstance(step, dict):
+                    step_provisioner_type, step_config = tuple(step.items())[0]
+                    REGISTERED_PROVISIONERS.get(step_provisioner_type)(self.incus, self.reporter).provision(
+                        instance_name, step_config
+                    )
+                else:
+                    REGISTERED_PROVISIONERS.get("script")(self.incus, self.reporter).provision(
+                        instance_name, step
+                    )
         else:
             self.reporter.info(f"No provisioning found for {instance_name}.")
-
-    def llmnr_setup(self, instance_name: str, llmnr_config: Union[dict, bool]) -> None:
-        """Enable LLMNR on an instance."""
-        if not llmnr_config:
-            return
-
-        self.reporter.success(f"Enabling LLMNR on instance {instance_name}...")
-        try:
-            self._install_systemd_resolved(instance_name)
-            self._configure_llmnr(instance_name)
-            self._restart_systemd_resolved(instance_name)
-            self.reporter.success(f"LLMNR enabled on {instance_name}.")
-        except IncusCommandError as e:
-            self.reporter.error(f"Failed to enable LLMNR on {instance_name}: {e}")
-
-    def _install_systemd_resolved(self, instance_name: str):
-        """Install systemd-resolved."""
-        self.reporter.info("Installing systemd-resolved...")
-        try:
-            self.incus.exec(instance_name, ["sh", "-c", "command -v apt-get"], capture_output=True)
-            self.incus.exec(
-                instance_name,
-                ["sh", "-c", "apt-get update && apt-get -y install systemd-resolved"],
-                capture_output=False,
-            )
-            return
-        except IncusCommandError:
-            pass  # apt-get not found, try next package manager
-
-        try:
-            self.incus.exec(instance_name, ["sh", "-c", "command -v dnf"], capture_output=True)
-            self.incus.exec(
-                instance_name, ["sh", "-c", "dnf -y -q install systemd-resolved"], capture_output=False
-            )
-            return
-        except IncusCommandError:
-            pass  # dnf not found
-
-        try:
-            self.incus.exec(instance_name, ["sh", "-c", "command -v pacman"], capture_output=True)
-            self.incus.exec(
-                instance_name,
-                ["sh", "-c", "pacman -Syu --noconfirm systemd-resolvconf"],
-                capture_output=False,
-            )
-            return
-        except IncusCommandError:
-            pass  # pacman not found
-
-        self.reporter.warning(
-            "Could not install systemd-resolved. No supported package manager (apt-get, dnf, pacman) found."
-        )
-
-    def _configure_llmnr(self, instance_name: str):
-        """Configure LLMNR in resolved.conf."""
-        self.reporter.info("Configuring LLMNR...")
-        script = """
-mkdir -p /etc/systemd/resolved.conf.d
-cat <<EOF > /etc/systemd/resolved.conf.d/llmnr.conf
-[Resolve]
-LLMNR=yes
-EOF
-"""
-        self.incus.exec(instance_name, ["sh", "-c", script])
-
-    def _restart_systemd_resolved(self, instance_name: str):
-        """Restart systemd-resolved service."""
-        self.reporter.info("Restarting systemd-resolved...")
-        self.incus.exec(instance_name, ["systemctl", "restart", "systemd-resolved"])
-
-    def clean_known_hosts(self, name: str) -> None:
-        """Remove an instance's name from the known_hosts file and add the new host key."""
-        self.reporter.success(
-            f"Updating {name} in known_hosts to avoid SSH warnings...",
-        )
-        known_hosts_path = Path.home() / ".ssh" / "known_hosts"
-        if known_hosts_path.exists():
-            try:
-                # Remove existing entry
-                subprocess.run(
-                    ["ssh-keygen", "-R", name], check=False, capture_output=True
-                )  # nosec B603, B607
-            except FileNotFoundError as e:
-                raise IncusCommandError("ssh-keygen not found, cannot clean known_hosts.") from e
-
-        # Initiate a connection to accept the new host key
-        try:
-            subprocess.run(  # nosec B603, B607
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=accept-new",
-                    "-o",
-                    "BatchMode=yes",
-                    "-o",
-                    "ConnectTimeout=5",
-                    name,
-                    "exit",  # Just connect and exit
-                ],
-                check=False,  # Don't raise an error if connection fails (e.g., SSH not ready yet)
-                capture_output=True,
-            )
-        except FileNotFoundError:
-            self.reporter.warning(
-                "ssh command not found, cannot add new host key to known_hosts.",
-            )
-
-    def _install_ssh_server(self, name: str) -> bool:
-        """Installs SSH server in the instance."""
-        package_managers: list[PackageManager] = [
-            {
-                "check_cmd": "command -v apt-get",
-                "install_cmds": ["apt-get update && apt-get -y install ssh"],
-            },
-            {
-                "check_cmd": "command -v dnf",
-                "install_cmds": [
-                    "dnf -y -q install openssh-server",
-                    "systemctl enable sshd",
-                    "systemctl start sshd",
-                ],
-            },
-            {
-                "check_cmd": "command -v pacman",
-                "install_cmds": [
-                    "pacman -Syu --noconfirm openssh",
-                    "systemctl enable sshd",
-                    "systemctl start sshd",
-                ],
-            },
-        ]
-
-        for pm in package_managers:
-            try:
-                self.incus.exec(name, ["sh", "-c", pm["check_cmd"]], capture_output=True)
-                for cmd in pm["install_cmds"]:
-                    self.incus.exec(name, ["sh", "-c", cmd], capture_output=False)
-                return True  # Installed
-            except IncusCommandError:
-                continue  # Try next package manager
-        return False  # Not installed
-
-    def _get_authorized_keys_content(self, ssh_config: Union[dict, bool]) -> str:
-        """Determines the content for authorized_keys."""
-        source_path_str = ssh_config.get("authorized_keys") if isinstance(ssh_config, dict) else None
-
-        if source_path_str:
-            source_path = Path(source_path_str).expanduser()
-            if source_path.exists():
-                with open(source_path, "r", encoding="utf-8") as f:
-                    return f.read()
-            else:
-                self.reporter.warning(
-                    f"Provided authorized_keys file not found: {source_path}. Skipping copy.",
-                )
-                return ""
-        else:
-            # Concatenate all public keys from ~/.ssh/id_*.pub
-            ssh_dir = Path.home() / ".ssh"
-            pub_keys_content = []
-            key_files = glob.glob(os.path.join(ssh_dir, "id_*.pub"))
-
-            for key_file_path in key_files:
-                with open(key_file_path, "r", encoding="utf-8") as f:
-                    pub_keys_content.append(f.read().strip())
-
-            if pub_keys_content:
-                return "\n".join(pub_keys_content) + "\n"
-            else:
-                self.reporter.warning(
-                    "No public keys found in ~/.ssh/id_*.pub and no authorized_keys file provided. "
-                    "SSH access might not be possible without a password.",
-                )
-                return ""
-
-    def _write_authorized_keys(self, name: str, content: str) -> None:
-        """Writes the authorized_keys content to the instance."""
-        if not content:
-            return
-
-        self.reporter.success(f"Filling authorized_keys in {name}...")
-        self.incus.exec(name, ["mkdir", "-p", "/root/.ssh"])
-
-        fd, temp_path = tempfile.mkstemp(prefix="incant_authorized_keys_")
-        try:
-            with os.fdopen(fd, "w") as temp_file:
-                temp_file.write(content)
-
-            self.incus.file_push(
-                FilePushConfig(
-                    instance_name=name,
-                    source=temp_path,
-                    target="/root/.ssh/authorized_keys",
-                    uid=0,
-                    gid=0,
-                    quiet=True,
-                )
-            )
-        finally:
-            os.remove(temp_path)
-
-    def ssh_setup(self, name: str, ssh_config: Union[dict, bool]) -> None:
-        """Install SSH server and copy authorized_keys."""
-        if isinstance(ssh_config, bool):
-            ssh_config = {"clean_known_hosts": True}
-
-        self.reporter.success(f"Installing SSH server in {name}...")
-        if not self._install_ssh_server(name):
-            self.reporter.error(
-                f"Failed to install SSH server in {name}. "
-                "No supported package manager (apt-get, dnf, pacman) found.",
-            )
-            return
-
-        content = self._get_authorized_keys_content(ssh_config)
-        self._write_authorized_keys(name, content)
-
-        if ssh_config.get("clean_known_hosts"):
-            self.clean_known_hosts(name)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,5 +1,6 @@
 import sys
 from io import StringIO
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -56,11 +57,17 @@ def mock_reporter():
     return MockReporter()
 
 
+@pytest.fixture
+def mock_incus_cli():
+    mock = Mock()
+    return mock
+
+
 def test_find_config_explicit_path(tmp_path, mock_reporter):
     """Test finding a config file with an explicit path."""
     config_file = tmp_path / "custom.yaml"
     config_file.write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file))
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
     assert cm.find_config_file() == config_file
 
 
@@ -70,13 +77,13 @@ def test_find_config_default_names(tmp_path, monkeypatch, mock_reporter):
 
     # Test incant.yaml
     (tmp_path / "incant.yaml").write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter)
+    cm = ConfigManager(mock_incus_cli, mock_reporter)
     assert cm.find_config_file().name == "incant.yaml"
     (tmp_path / "incant.yaml").unlink()
 
     # Test .incant.yaml
     (tmp_path / ".incant.yaml").write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter)
+    cm = ConfigManager(mock_incus_cli, mock_reporter)
     assert cm.find_config_file().name == ".incant.yaml"
 
 
@@ -84,14 +91,14 @@ def test_find_config_no_file(tmp_path, monkeypatch, mock_reporter):
     """Test that ConfigurationError is raised when no config file is found."""
     monkeypatch.chdir(tmp_path)
     with pytest.raises(ConfigurationError, match="Config file not found"):
-        ConfigManager(mock_reporter)
+        ConfigManager(mock_incus_cli, mock_reporter)
 
 
 def test_dump_config(tmp_path, monkeypatch, mock_reporter):
     """Test dumping the configuration to stdout."""
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file))
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
 
     captured_output = StringIO()
     monkeypatch.setattr(sys, "stdout", captured_output)
@@ -104,7 +111,7 @@ def test_dump_config(tmp_path, monkeypatch, mock_reporter):
 
 def test_dump_config_no_config(mock_reporter):
     """Test that dumping with no config raises an error."""
-    cm = ConfigManager(mock_reporter, no_config=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, no_config=True)
     with pytest.raises(ConfigurationError, match="No configuration to dump"):
         cm.dump_config()
 
@@ -112,7 +119,7 @@ def test_dump_config_no_config(mock_reporter):
 def test_load_config_file_not_found(tmp_path, mock_reporter):
     """Test loading a non-existent config file raises ConfigurationError."""
     config_file = tmp_path / "non_existent.yaml"
-    cm = ConfigManager(mock_reporter, config_path=str(config_file), no_config=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file), no_config=True)
     with pytest.raises(ConfigurationError, match="Config file not found"):
         cm.load_config()
 
@@ -121,7 +128,7 @@ def test_load_config_jinja_template_error(tmp_path, mock_reporter):
     """Test that Jinja2 template rendering errors are caught."""
     config_file = tmp_path / "incant.yaml.j2"
     config_file.write_text("{{ invalid_syntax ")
-    cm = ConfigManager(mock_reporter, config_path=str(config_file), no_config=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file), no_config=True)
     with pytest.raises(ConfigurationError, match="Error rendering template") as excinfo:
         cm.load_config()
     assert isinstance(excinfo.value.__cause__, jinja_exceptions.TemplateSyntaxError)
@@ -131,7 +138,7 @@ def test_load_config_mako_template_error(tmp_path, mock_reporter):
     """Test that Mako template rendering errors are caught."""
     config_file = tmp_path / "incant.yaml.mako"
     config_file.write_text("${ invalid_syntax ")
-    cm = ConfigManager(mock_reporter, config_path=str(config_file), no_config=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file), no_config=True)
     with pytest.raises(ConfigurationError, match="Error rendering template") as excinfo:
         cm.load_config()
     assert isinstance(excinfo.value.__cause__, mako_exceptions.SyntaxException)
@@ -141,7 +148,7 @@ def test_load_config_yaml_error(tmp_path, mock_reporter):
     """Test that YAML parsing errors are caught."""
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(INVALID_YAML)
-    cm = ConfigManager(mock_reporter, config_path=str(config_file), no_config=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file), no_config=True)
     with pytest.raises(ConfigurationError, match="Error parsing YAML file") as excinfo:
         cm.load_config()
     assert isinstance(excinfo.value.__cause__, yaml.YAMLError)
@@ -151,7 +158,7 @@ def test_dump_config_exception(tmp_path, monkeypatch, mock_reporter):
     """Test that exceptions during config dumping are caught."""
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file))
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
 
     def mock_dump(*args, **kwargs):
         raise Exception("Mock dump error")
@@ -165,7 +172,7 @@ def test_find_config_verbose_output(tmp_path, mock_reporter):
     """Test verbose output when config file is found."""
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file), verbose=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file), verbose=True)
     cm.find_config_file()
     assert any("Config found at:" in msg for _, msg in mock_reporter.messages)
 
@@ -174,7 +181,7 @@ def test_load_config_verbose_output(tmp_path, mock_reporter):
     """Test verbose output when config is loaded successfully."""
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(VALID_CONFIG))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file), verbose=True)
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file), verbose=True)
     cm.load_config()
     assert any("Config loaded successfully from" in msg for _, msg in mock_reporter.messages)
 
@@ -185,14 +192,14 @@ def test_validate_config_no_instances(tmp_path, mock_reporter):
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(config))
     with pytest.raises(ConfigurationError, match="No instances found in config"):
-        ConfigManager(mock_reporter, config_path=str(config_file))
+        ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
 
 
 def test_init_with_empty_config_file(tmp_path, mock_reporter):
     """Test that ConfigManager handles an empty config file gracefully."""
     config_file = tmp_path / "incant.yaml"
     config_file.write_text("")  # Empty file
-    cm = ConfigManager(mock_reporter, config_path=str(config_file))
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
     assert cm._config_data is None
     assert cm.instance_configs == {}
 
@@ -203,7 +210,7 @@ def test_init_with_no_instances_in_config(tmp_path, mock_reporter):
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(config))
     with pytest.raises(ConfigurationError, match="No instances found in config"):
-        ConfigManager(mock_reporter, config_path=str(config_file))
+        ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
 
 
 def test_valid_config_no_provision(tmp_path, mock_reporter):
@@ -211,7 +218,7 @@ def test_valid_config_no_provision(tmp_path, mock_reporter):
     config = {"instances": {"test": {"image": "ubuntu"}}}
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(config))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file))
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
     # No exception should be raised
     assert cm.instance_configs["test"].provision is None
 
@@ -221,6 +228,6 @@ def test_valid_config_no_pre_launch(tmp_path, mock_reporter):
     config = {"instances": {"test": {"image": "ubuntu"}}}
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(config))
-    cm = ConfigManager(mock_reporter, config_path=str(config_file))
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
     # No exception should be raised
     assert cm.instance_configs["test"].pre_launch_cmds == []

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -231,3 +231,27 @@ def test_valid_config_no_pre_launch(tmp_path, mock_reporter):
     cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
     # No exception should be raised
     assert cm.instance_configs["test"].pre_launch_cmds == []
+
+
+def test_valid_provision_steps(tmp_path, mock_reporter, mock_incus_cli):
+    """Test that valid provision steps are accepted."""
+    config = {
+        "instances": {
+            "test": {
+                "image": "ubuntu",
+                "provision": [
+                    {"llmnr": True},
+                    {"ssh": True},
+                    {"copy": {"source": "src", "target": "dest"}},
+                    "script.sh",
+                ],
+            }
+        }
+    }
+    config_file = tmp_path / "incant.yaml"
+    config_file.write_text(yaml.dump(config))
+
+    # Should not raise any exception
+    cm = ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
+    cm.load_config()
+    cm.validate_config()

--- a/tests/test_incant.py
+++ b/tests/test_incant.py
@@ -282,7 +282,7 @@ class TestIncant:
         mock_incus_cli.is_agent_running.assert_called_once_with("test-instance")
         mock_incus_cli.is_agent_usable.assert_called_once_with("test-instance")
         mock_incus_cli.is_instance_ready.assert_called_once_with("test-instance", True)
-        incant_app.provisioner.provision.assert_not_called()
+        incant_app.provision_manager.provision.assert_not_called()
 
     @patch("incant.incant.time.sleep", return_value=None)
     def test_up_single_instance_with_shared_folder(

--- a/tests/test_incant.py
+++ b/tests/test_incant.py
@@ -59,7 +59,7 @@ def incant_app(mock_reporter, mock_config_manager, mock_incus_cli, mock_provisio
     with patch("incant.incant.ConfigManager", return_value=mock_config_manager):
         app = Incant(reporter=mock_reporter)
         app.incus = mock_incus_cli
-        app.provisioner = mock_provision_manager
+        app.provision_manager = mock_provision_manager
         return app
 
 
@@ -206,7 +206,7 @@ class TestIncant:
         mock_incus_cli.is_agent_usable.assert_called_once_with("test-instance")
         mock_incus_cli.is_instance_ready.assert_not_called()
         mock_incus_cli.create_shared_folder.assert_not_called()
-        incant_app.provisioner.provision.assert_not_called()
+        incant_app.provision_manager.provision.assert_not_called()
         assert ("success", "Creating instance test-instance with image img...") in mock_reporter.messages
         assert ("success", "Sharing current directory to test-instance:/incant ...") in mock_reporter.messages
 
@@ -256,7 +256,7 @@ class TestIncant:
         mock_incus_cli.is_agent_running.assert_called_once_with("test-instance")
         mock_incus_cli.is_agent_usable.assert_called_once_with("test-instance")
         mock_incus_cli.is_instance_ready.assert_called_once_with("test-instance", True)
-        incant_app.provisioner.provision.assert_called_once_with("test-instance", ["script.sh"])
+        incant_app.provision_manager.provision.assert_called_once_with("test-instance", ["script.sh"])
 
     @patch("incant.incant.time.sleep", return_value=None)
     def test_up_single_instance_with_provision_but_disabled(

--- a/tests/test_invalid_configs.py
+++ b/tests/test_invalid_configs.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 import yaml
 
@@ -33,11 +35,17 @@ def mock_reporter():
     return MockReporter()
 
 
+@pytest.fixture
+def mock_incus_cli():
+    mock = Mock()
+    return mock
+
+
 def run_test_with_config(tmp_path, mock_reporter, config, error_msg):
     config_file = tmp_path / "incant.yaml"
     config_file.write_text(yaml.dump(config))
     with pytest.raises(ConfigurationError, match=error_msg):
-        ConfigManager(mock_reporter, config_path=str(config_file))
+        ConfigManager(mock_incus_cli, mock_reporter, config_path=str(config_file))
 
 
 def test_missing_image(tmp_path, mock_reporter):

--- a/tests/test_provision_manager.py
+++ b/tests/test_provision_manager.py
@@ -1,0 +1,72 @@
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from incant.exceptions import IncusCommandError
+from incant.provisioning_manager import ProvisionManager
+from incant.reporter import Reporter
+
+
+@pytest.fixture
+def mock_incus_cli():
+    return Mock()
+
+
+@pytest.fixture
+def mock_reporter():
+    return Mock(spec=Reporter)
+
+
+def test_provision_llmnr(mock_incus_cli, mock_reporter):
+    """Test that LLMNR provisioning calls the expected incus commands."""
+    pm = ProvisionManager(mock_incus_cli, mock_reporter)
+
+    # Mock exec to simulate apt-get presence
+    # The first call checks for apt-get, we want it to succeed (return None or empty)
+    # The second call installs it.
+    # Subsequent calls are for configuration.
+    mock_incus_cli.exec.return_value = None
+
+    instance_name = "test-instance"
+    provision_config = [{"llmnr": True}]
+
+    pm.provision(instance_name, provision_config)
+
+    # Verify calls
+    # 1. Check apt-get
+    # 2. Install package
+    # 3. Configure file
+    # 4. Restart service
+
+    # We check that at least the installation was attempted
+    assert (
+        call(instance_name, ["sh", "-c", "command -v apt-get"], capture_output=True)
+        in mock_incus_cli.exec.call_args_list
+    )
+    assert (
+        call(
+            instance_name,
+            ["sh", "-c", "apt-get update && apt-get -y install systemd-resolved"],
+            capture_output=False,
+        )
+        in mock_incus_cli.exec.call_args_list
+    )
+
+    # Verify reporter success message
+    mock_reporter.success.assert_any_call(f"LLMNR enabled on {instance_name}.")
+
+
+def test_provision_unknown_provisioner_runtime_check(mock_incus_cli, mock_reporter):
+    """
+    Test that ProvisionManager handles provisioners safely.
+    Note: Ideally ConfigManager catches unknown keys before this,
+    but ProvisionManager should also be robust or at least fail clearly if passed invalid data.
+    """
+    pm = ProvisionManager(mock_incus_cli, mock_reporter)
+
+    # We need to bypass ConfigManager validation to test this runtime behavior
+    # or we can rely on the fact that ConfigManager would have raised an error.
+    # Here we simulate a "script" step just to prove the manager works.
+
+    pm.provision("test", ["echo hello"])
+    mock_incus_cli.run_script.assert_called_with("test", "echo hello")


### PR DESCRIPTION
This refactors the provisioning logic so that every provisioner is defined by its own class. This better encapsulates provisoner logic and makes adding new provisioners easier.

While this is supposed to be a pure refactoring, it contains a small functional change, so that provisioning scripts can now not just be put as string only in the provisioner config, but following a "script" key as well, similar to all other provisioners.