### PR TITLE
Draft: Add support for shared folders

### DIFF
--- a/incant/incant.py
+++ b/incant/incant.py
@@ -83,6 +83,12 @@ class Incant:
             if instance_config.shared_folder:
                 self.incus.create_shared_folder(instance_config.name)
 
+            if instance_config.shared_folders:
+                self.incus.create_shared_folders(
+                    instance_config.name,
+                    instance_config.shared_folders,
+                )
+
             if instance_config.provision and provision:
                 # Automatically run provisioning after instance creation
                 self.provision(instance_config.name)

--- a/incant/incus_cli.py
+++ b/incant/incus_cli.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import shlex
@@ -110,15 +111,23 @@ class IncusCLI:
 
     def create_shared_folder(self, name: str) -> None:
         curdir = Path.cwd()
+        self.create_shared_folder_device(name, source=str(curdir), path='/incant')
+
+    def create_shared_folder_device(self, name: str, source: str, path: str) -> None:
+        device_name = "{name}_shared_{hash}".format(
+            name=name,
+            hash=hashlib.sha1(path.encode()).hexdigest()[:10],
+        )
+
         command = [
             "config",
             "device",
             "add",
             name,
-            f"{name}_shared_incant",
+            device_name,
             "disk",
-            f"source={curdir}",
-            "path=/incant",
+            f"source={source}",
+            f"path={path}",
             "shift=true",  # First attempt with shift enabled
         ]
 
@@ -153,7 +162,7 @@ class IncusCLI:
                 "Shared folder creation failed (/incant not mounted). Retrying...",
             )
             self._run_command(
-                ["config", "device", "remove", name, f"{name}_shared_incant"],
+                ["config", "device", "remove", name, device_name],
                 capture_output=False,
             )
             self._run_command(command, capture_output=False)

--- a/incant/incus_cli.py
+++ b/incant/incus_cli.py
@@ -113,6 +113,17 @@ class IncusCLI:
         curdir = Path.cwd()
         self.create_shared_folder_device(name, source=str(curdir), path='/incant')
 
+    def create_shared_folders(self, name: str, shared_folders: List[str]) -> None:
+        curdir = Path.cwd()
+
+        for shared_folder in shared_folders:
+            source, path = shared_folder.split(':')
+
+            source = (curdir / Path(source.strip())).absolute()
+            path = path.strip()
+
+            self.create_shared_folder_device(name, source=source, path=path)
+
     def create_shared_folder_device(self, name: str, source: str, path: str) -> None:
         device_name = "{name}_shared_{hash}".format(
             name=name,

--- a/incant/types.py
+++ b/incant/types.py
@@ -20,6 +20,7 @@ class InstanceConfig:
     pre_launch_cmds: Optional[List[str]] = field(default_factory=list)
     wait: bool = False
     shared_folder: bool = True
+    shared_folders: Optional[List[str]] = None
     provision: Optional[ProvisionSteps] = None
 
 


### PR DESCRIPTION
This adds support for custom shared folders (in addition to the default `/incant` shared folder)

Shared folders can be defined in the configuration file in the form:

```
instance:
  shared_folders:
    - <source path>:<instance path>
    - <source path>:<instance path>
```

Relative source paths (ie. `./folder`) are treated relative to the current working directory. This is keeping with the existing behaviour for `/incant`, though having said that I personally think it would make more sense for paths to be relative to the configuration file parent directory.

We `strip()` the path string parts of white space so that configurations could use the following form for improved readability:

```
instance:
  shared_folders:
    - "<source path> : <instance path>"
    - "<source path> : <instance path>"

Note: the entries needed to enclosed by "s otherwise the entries are treated as `dict` objects.

---

I'm happy to make changes if a different approach is preferred.